### PR TITLE
Load entire appinfo.vdf since loading selectively is broken

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -52,9 +52,7 @@ class MainWindow:
         if export is not None:
             self.modifiedApps.extend(export)
             self.load_modifications()
-            self.appinfo = Appinfo(
-                self.vdf_path, True, apps=self.modifiedApps
-            )
+            self.appinfo = Appinfo(self.vdf_path)
 
             for app in self.modifiedApps:
                 self.save_original_data(app)
@@ -63,9 +61,7 @@ class MainWindow:
 
         if silent:
             self.load_modifications()
-            self.appinfo = Appinfo(
-                self.vdf_path, True, apps=self.modifiedApps
-            )
+            self.appinfo = Appinfo(self.vdf_path)
 
             for app in self.modifiedApps:
                 self.appinfo.parsedAppInfo[app]["sections"] = self.jsonData[


### PR DESCRIPTION
Name entails. Normally this doesn't affect the user at all, but when trying to run the program with the `--silent` flag, it immediately crashes due to an indexing error. It probably has something to do with how you are reading the VDF file. The reason I made this PR rather than simply opening up an issue was because since #50 exists, I'd imagine all the work into cleaning up how the application works would be put into the GTK rewrite.

Of course, this PR is a really quick and dirty fix to a problem that I hope would be solved by the GTK rewrite. When this program is loaded in GUI mode, the "save" button indiscriminately writes to the entire `appinfo.vdf` file, since it doesn't load it selectively like the silent or export flags do. Since this merely makes it so that silent mode loads the entire `appinfo.vdf` file, just like how it would in the normal GUI mode, the only real impact here is performance.